### PR TITLE
Add totals to heap analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ $ heapy read tmp/2015-10-01T10:18:59-05:00-heap.dump 17
          92200  /app/vendor/bundle/ruby/2.2.0/gems/activesupport-4.2.3/lib/active_support/core_ext/numeric/conversions.rb:131
 ```
 
+### Reviewing all generations
+
 If you want to read all generations you can use the "all" directive
 
 ```

--- a/lib/heapy.rb
+++ b/lib/heapy.rb
@@ -184,17 +184,30 @@ HALP
 
       # generation number is key, value is count
       data = Hash.new {|h, k| h[k] = 0 }
+      mem = Hash.new {|h, k| h[k] = 0 }
+      total_count = 0
+      total_mem = 0
 
       read do |parsed|
         data[parsed["generation"] || 0] += 1
+        mem[parsed["generation"] || 0] += parsed["memsize"] || 0
       end
 
       data = data.sort {|(k1,v1), (k2,v2)| k1 <=> k2 }
       max_length = [data.last[0].to_s.length, default_key.length].max
       data.each do |generation, count|
         generation = default_key if generation == 0
-        puts "Generation: #{ generation.to_s.rjust(max_length) } object count: #{ count }"
+        total_count += count
+        total_mem += mem[generation]
+        puts "Generation: #{ generation.to_s.rjust(max_length) } object count: #{ count }, mem: #{(mem[generation].to_f / 1024).round(1)} kb"
       end
+
+      puts ""
+      puts "Heap total"
+      puts "=============="
+      puts "Generations (active): #{data.length}"
+      puts "Count: #{total_count}"
+      puts "Memory: #{(total_mem.to_f / 1024).round(1)} kb"
     end
   end
 end

--- a/spec/heap_inspect_spec.rb
+++ b/spec/heap_inspect_spec.rb
@@ -23,8 +23,19 @@ describe Heapy do
     expect(out).to match("1672  /Users/richardschneeman/.gem/ruby/2.2.3/gems/activerecord-4.2.3/lib/active_record/attribute.rb:5")
   end
 
-  it 'analyzes' do
-    out = run("bin/heapy read #{ fixtures('00-heap.dump') }")
-    expect(out).to match("Generation: nil object count: 209189")
+  context 'with no generation specified' do
+    let(:cmd) { "bin/heapy read #{ fixtures('00-heap.dump') }" }
+    it 'analyzes' do
+      out = run(cmd)
+      expect(out).to match("Generation: nil object count: 209189")
+    end
+
+    it "summarizes" do
+      out = run(cmd)
+      expect(out).to include("Heap total")
+      expect(out).to include("Generations (active): 5")
+      expect(out).to include("Count: 278443")
+      expect(out).to include("Memory: 8004.6 kb")
+    end
   end
 end


### PR DESCRIPTION
I found that when comparing different heap dumps it's hard to see if a) things are growing in total, b) each generation is large / small as an absolute value.

This PR simply adds memory totals to each generation + a total at the end