### PR TITLE
Fix heap dumps showing incorrectly retained objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@
 /spec/reports/
 /tmp/
 tmp
-
+.DS_Store

--- a/spec/slow_spec.rb
+++ b/spec/slow_spec.rb
@@ -1,0 +1,8 @@
+describe Heapy::Alive do
+  it "passes all the edge cases" do
+    Tempfile.open('heap') do |f|
+      out = run("env HEAP_FILE=#{f.path} ruby #{ fixtures('../../weird_memory/run.rb') }")
+      expect(out).to_not match("FAIL")
+    end
+  end
+end


### PR DESCRIPTION
There is a problem with using heap dumps to detect when an object is retained or freed. Even after calling `GC.start` sometimes an object with no references to it will still be in the heap dump. This commit fixes that problem.

I ran into this problem with https://github.com/schneems/living_dead which uses the tracepoint C interface to basically do the same thing as `Heapy::Alive` except it doesn't need to write a heap dump to disk. You can see nearly identical code here: https://github.com/schneems/living_dead/blob/22a806e5a6f7d5c77a8d9bb150a4aa76faf91690/lib/living_dead.rb#L30-L60

Before this commit, running the command:

```
$ ruby weird_memory/run.rb ALL
```


Would give a few failures. After this patch, there are no failures.

> I added this into the tests under `spec/slow_spec.rb`

Why does our change fix things? Let's break it down into parts.

Calling `CG.start` multiple times kinda seems reasonable. Ruby has incremental GC and maybe we're not done fully marking and sweeping all objects? Even so, seems calling `GC.start` should run through the whole GC process, so I don't know why this is needed?

Unfortunately calling `GC.start` multiple times doesn't make our examples pass. We still need the `puts` call in there. Why?

I have no freaking clue. It's not the extra object creation, i tried doing all sorts of `1000.times { a = "asldkfjasdlkfj".dup }` and that didn't help at all. So there seems to be something special going on with the `puts` call. Even weirder is that it works both on `Kernel#puts` and `StringIO#puts.

In summary of why this works and is needed...

![](https://imgflip.com/s/meme/Jackie-Chan-WTF.jpg)