### PR TITLE
[ci skip] Fix broken link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/heapy. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](contributor-covenant.org) code of conduct.
+Bug reports and pull requests are welcome on GitHub at https://github.com/schneems/heapy. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](contributor-covenant.org) code of conduct.
 
 
 ## License


### PR DESCRIPTION
Hey,

Nothing major here. I was just reading through the README for this project and noticed that this link was broken.

Thanks for making this project. Some coworkers and I recently spent a few hours tracking down a memory leak. We cobbled together a script just like this one based on Sam Saffron's post. I was planning to try to formalize it into a gem, but now I'm quite happy to see that you beat me to it.

Thanks so much!

