### PR TITLE
add required_ruby_version

### DIFF
--- a/heapy.gemspec
+++ b/heapy.gemspec
@@ -22,4 +22,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec"
+  spec.required_ruby_version = '>= 2.3.0'
 end


### PR DESCRIPTION
The use of safe-navigation operator (`&.`) in this library (in [alive.rb](https://github.com/schneems/heapy/blob/master/lib/heapy/alive.rb#L133)) requires Ruby `>= 2.3.0` - this can be made explicit using `required_ruby_version`.