### PR TITLE
Heapy can't work before Ruby 2.3

### DIFF
--- a/heapy.gemspec
+++ b/heapy.gemspec
@@ -22,4 +22,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec"
+  
+  spec.required_ruby_version = '~> 2.3'
 end


### PR DESCRIPTION
Since it uses the safe navigation operator that was introduced in that version: 
https://github.com/schneems/heapy/blob/e21be68fa11421afd78f3a4b61bdc2fbe79ab00e/lib/heapy/alive.rb#L133

```
$ heapy read ruby-heap-2018-07-24\ 01\:29\:05.dump
/Users/olivierlacan/.rbenv/versions/2.1.6/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require': /Users/olivierlacan/.rbenv/versions/2.1.6/lib/ruby/gems/2.1.0/gems/heapy-0.1.3/lib/heapy/alive.rb:133: syntax error, unexpected '.' (SyntaxError)
...lf.address_to_object(address)&.inspect || "object not traced...
...                               ^
```