### PR TITLE
Don't require Bundler if it's not available

### DIFF
--- a/bin/heapy
+++ b/bin/heapy
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 
-require "bundler/setup"
+require "bundler/setup" if defined?(Bundler)
 require "heapy"
 
 


### PR DESCRIPTION
I didn't go so far as to remove the require altogether but this fixes
usage of heapy from gem install in an environment with no Gemfile.

Fixes #19