### PR TITLE
New command: ref-explore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD
 
+- New command `heapy ref-explore` (https://github.com/zombocom/heapy/pull/33)
+
 ## 0.2.0
 
 - Heapy::Alive is removed (https://github.com/schneems/heapy/pull/27)

--- a/lib/heapy.rb
+++ b/lib/heapy.rb
@@ -67,6 +67,33 @@ module Heapy
       Diff.new(before: before, after: after, retained: retained, output_diff: options[:output_diff] || nil).call
     end
 
+    long_desc <<-DESC
+      Follows references to given object addresses and prints them as a reference stack. This can for example be useful
+      if you are wondering why a given object has not been garbage collected.
+
+      Run with a list of addresses to get results for reference stacks to all the given addresses
+
+        $ heapy ref-explore my.dump 0xabcdef 0xdeadbeef\x5
+
+      Run without specifying addresses to get an interactive prompt that asks you to enter one address at a time
+
+        $ heapy ref-explore my.dump\x5
+
+    DESC
+    desc "ref-explore <file> [<address>...]", "Follows references to a given object"
+    def ref_explore(file, *addresses)
+      explorer = ReferenceExplorer.new(file)
+      if addresses.any?
+        explorer.drill_down_list(addresses)
+      else
+        begin
+          explorer.drill_down_interactive
+        rescue Interrupt
+          nil
+        end
+      end
+    end
+
     map %w[--version -v] => :version
     desc "version", "Show heapy version"
     def version
@@ -103,3 +130,4 @@ end
 
 require 'heapy/analyzer'
 require 'heapy/diff'
+require 'heapy/reference_explorer'

--- a/lib/heapy/reference_explorer.rb
+++ b/lib/heapy/reference_explorer.rb
@@ -1,0 +1,161 @@
+require 'json'
+require 'readline'
+require 'set'
+
+module Heapy
+
+  # Follows references to given object addresses and prints
+  # them as a reference stack.
+  # Since multiple reference stacks are possible, it will preferably
+  # try to print a stack that leads to a root node, since reference chains
+  # leading to a root node will make an object non-collectible by GC.
+  #
+  # In case no chain to a root node can be found one possible stack is printed
+  # as a fallback.
+  class ReferenceExplorer
+    def initialize(filename)
+      @objects = {}
+      @reverse_references = {}
+      @virtual_root_address = 0
+      File.open(filename) do |f|
+        f.each.with_index do |line, i|
+          o = JSON.parse(line)
+          addr = add_object(o)
+          add_reverse_references(o, addr)
+          add_class_references(o, addr)
+        end
+      end
+    end
+
+    def drill_down_list(addresses)
+      addresses.each { |addr| drill_down(addr) }
+    end
+
+    def drill_down_interactive
+      while buf = Readline.readline("Enter address > ", true)
+        drill_down(buf)
+      end
+    end
+
+    def drill_down(addr_string)
+      addr = addr_string.to_i(16)
+      puts
+
+      chain = find_root_chain(addr)
+      unless chain
+        puts 'Could not find a reference chain leading to a root node. Searching for a non-specific chain now.'
+        puts
+        chain = find_any_chain(addr)
+      end
+
+      puts '## Reference chain'
+      chain.each do |ref|
+        puts format_object(ref)
+      end
+
+      puts
+      puts "## All references to #{addr_string}"
+      refs = @reverse_references[addr] || []
+      refs.each do |ref|
+        puts " * #{format_object(ref)}"
+      end
+
+      puts
+    end
+
+    def inspect
+      "<ReferenceExplorer #{@objects.size} objects; #{@reverse_references.size} back-refs>"
+    end
+
+    private
+
+    def add_object(o)
+      addr = o['address']&.to_i(16)
+      if !addr && o['type'] == 'ROOT'
+        addr = @virtual_root_address
+        o['name'] ||= o['root']
+        @virtual_root_address += 1
+      end
+
+      return unless addr
+
+      simple_object = o.slice('type', 'file', 'name', 'class', 'length', 'imemo_type')
+      simple_object['class'] = simple_object['class'].to_i(16) if simple_object.key?('class')
+      simple_object['file'] = o['file'] + ":#{o['line']}" if o.key?('file') && o.key?('line')
+
+      @objects[addr] = simple_object
+
+      addr
+    end
+
+    def add_reverse_references(o, addr)
+      return unless o.key?('references')
+      o.fetch('references').map { |r| r.to_i(16) }.each do |ref|
+        (@reverse_references[ref] ||= []) << addr
+      end
+    end
+
+    # An instance of a class keeps that class marked by the GC.
+    # This is not directly indicated as a reference in a heap dump,
+    # so we manually introduce the back-reference.
+    def add_class_references(o, addr)
+      return unless o.key?('class')
+      return if o['type'] == 'IMEMO'
+
+      class_addr = o.fetch('class').to_i(16)
+      (@reverse_references[class_addr] ||= []) << addr
+    end
+
+    def find_root_chain(addr, known_addresses = Set.new)
+      known_addresses << addr
+
+      return [addr] if addr < @virtual_root_address # assumption: only root objects have smallest possible addresses
+
+      references = @reverse_references[addr] || []
+
+      references.reject { |a| known_addresses.include?(a) }.each do |ref|
+        path = find_root_chain(ref, known_addresses)
+        return [addr] + path if path
+      end
+
+      nil
+    end
+
+    def find_any_chain(addr, known_addresses = Set.new)
+      known_addresses << addr
+
+      references = @reverse_references[addr] || []
+
+      next_ref = references.reject { |a| known_addresses.include?(a) }.first
+      if next_ref
+        [addr] + find_any_chain(next_ref, known_addresses)
+      else
+        []
+      end
+    end
+
+    def format_path(path)
+      return '' unless path
+
+      path.split('/').reverse.take(4).reverse.join('/')
+    end
+
+    def format_object(addr)
+      obj = @objects[addr]
+      return "<Unknown 0x#{addr.to_s(16)}>" unless obj
+
+      desc =  if obj['name']
+                obj['name']
+              elsif obj['type'] == 'OBJECT'
+                @objects.dig(obj['class'], 'name')
+              elsif obj['type'] == 'ARRAY'
+                "#{obj['length']} items"
+              elsif obj['type'] == 'IMEMO'
+                obj['imemo_type']
+              end
+      desc = desc ? " #{desc}" : ''
+      addr = addr ? " 0x#{addr.to_s(16).upcase}" : ''
+      "<#{obj['type']}#{desc}#{addr}> (allocated at #{format_path obj['file']})"
+    end
+  end
+end

--- a/lib/heapy/reference_explorer.rb
+++ b/lib/heapy/reference_explorer.rb
@@ -79,7 +79,7 @@ module Heapy
 
       return unless addr
 
-      simple_object = o.slice('type', 'file', 'name', 'class', 'length', 'imemo_type')
+      simple_object = o.select { |k, _v| %w[type file name class length imemo_type].include?(k) }
       simple_object['class'] = simple_object['class'].to_i(16) if simple_object.key?('class')
       simple_object['file'] = o['file'] + ":#{o['line']}" if o.key?('file') && o.key?('line')
 

--- a/spec/reference_explorer_spec.rb
+++ b/spec/reference_explorer_spec.rb
@@ -8,11 +8,13 @@ describe Heapy::ReferenceExplorer do
   let(:output) { stdout.string }
 
   around(:each) do |ex|
-    original = $stdout
-    $stdout = stdout
-    ex.run
-  ensure
-    $stdout = original
+    begin
+      original = $stdout
+      $stdout = stdout
+      ex.run
+    ensure
+      $stdout = original
+    end
   end
 
   describe 'when inspecting an object address' do

--- a/spec/reference_explorer_spec.rb
+++ b/spec/reference_explorer_spec.rb
@@ -1,0 +1,66 @@
+require 'spec_helper'
+
+describe Heapy::ReferenceExplorer do
+  subject { described_class.new(file_name).drill_down(address) }
+
+  let(:file_name) { 'spec/fixtures/dumps/01-ref-explore.dump' }
+  let(:stdout) { StringIO.new }
+  let(:output) { stdout.string }
+
+  around(:each) do |ex|
+    original = $stdout
+    $stdout = stdout
+    ex.run
+  ensure
+    $stdout = original
+  end
+
+  describe 'when inspecting an object address' do
+    let(:address) { '0x7f6bd8d961b0' }
+    let(:expected_output) do
+      <<~OUTPUT
+        ## Reference chain
+        <OBJECT MyClass 0x7F6BD8D961B0> (allocated at test.rb:5)
+        <IMEMO env 0x7F6BD8D9A788> (allocated at )
+        <DATA 0x7F6BD8D6A7B8> (allocated at )
+        <ROOT vm 0x0> (allocated at )
+      OUTPUT
+    end
+
+    it 'prints the reference chain' do
+      subject
+
+      expect(output).to include(expected_output)
+    end
+
+    context 'when passing the address in all-caps' do
+      let(:address) { '0x7F6BD8D961B0' }
+
+      it 'prints the reference chain' do
+        subject
+
+        expect(output).to include(expected_output)
+      end
+    end
+  end
+
+  describe 'when inspecting an invalid object address' do
+    let(:address) { '0xdeadbeef' }
+
+    it 'prints an error message' do
+      subject
+
+      expect(output).to include('Could not find a reference chain leading to a root node.')
+    end
+  end
+
+  describe 'when inspecting an anonymous class with a live instance' do
+    let(:address) { '0x7f6bd46fb868' }
+
+    it 'indicates a reference by the live instance' do
+      subject
+
+      expect(output).to include('OBJECT MyClass')
+    end
+  end
+end


### PR DESCRIPTION
Hello :wave: 

First of all: Thanks for heapy. It was already helpful a bunch of times when figuring out where a memory leak originated.

## What's in this PR?

This pull request adds a new feature to heapy that allows to follow the references to a given object.

Use case: You are analyzing a memory bloating issue and found out that a lot of very old GC generations still contain hundreds of `ActiveRecord` object instances. This information alone does not yet tell you, why you have so many objects that have not been garbage collected. You just know **what** is retained, but not **why**.

If you find an address of one of these objects (note: finding an address is out of scope for this PR), you can now follow the references to it and see why it has not been collected.

## Example

Taking the fixture included in this repo as an example. The new command can run non-interactively (as all heapy commands do so far):

```
$ bin/heapy ref-explore spec/fixtures/dumps/00-heap.dump 0x7fb47763feb0

## Reference chain
<OBJECT ActiveRecord::Attribute::FromDatabase 0x7FB47763FEB0> (allocated at activerecord-4.2.3/lib/active_record/attribute.rb:5)
<HASH 0x7FB474CA1A90> (allocated at lib/active_record/attribute_set/builder.rb:30)
<OBJECT ActiveRecord::LazyAttributeHash 0x7FB474CA1B30> (allocated at lib/active_record/attribute_set/builder.rb:16)
<OBJECT ActiveRecord::AttributeSet 0x7FB474CA1A68> (allocated at lib/active_record/attribute_set/builder.rb:17)
<OBJECT Repo 0x7FB474CA1A40> (allocated at activerecord-4.2.3/lib/active_record/core.rb:114)
<ARRAY 996 items 0x7FB474D790A8> (allocated at activerecord-4.2.3/lib/active_record/querying.rb:50)
<OBJECT Repo::ActiveRecord_Relation 0x7FB476A8BE98> (allocated at lib/active_record/relation/spawn_methods.rb:10)
<OBJECT PagesController 0x7FB476AB25C0> (allocated at actionpack-4.2.3/lib/action_controller/metal.rb:237)
<HASH 0x7FB4772EAE68> (allocated at rack-1.6.4/lib/rack/mock.rb:92)
<OBJECT ActionDispatch::Request 0x7FB476AB2480> (allocated at actionpack-4.2.3/lib/action_controller/metal.rb:237)
<OBJECT ActionDispatch::Response 0x7FB476AB2458> (allocated at lib/action_controller/metal/rack_delegation.rb:28)
<ROOT machine_context 0x2> (allocated at )

## All references to 0x7fb47763feb0
 * <HASH 0x7FB474CA1A90> (allocated at lib/active_record/attribute_set/builder.rb:30)
```

However, since the initial loading can take some time, there is also an interactive mode, where the dump is loaded once and the user can enter address after address:

```
$ bin/heapy ref-explore spec/fixtures/dumps/00-heap.dump
Enter address to inspect: 0x7fb47763feb0

## Reference chain
<OBJECT ActiveRecord::Attribute::FromDatabase 0x7FB47763FEB0> (allocated at activerecord-4.2.3/lib/active_record/attribute.rb:5)
<HASH 0x7FB474CA1A90> (allocated at lib/active_record/attribute_set/builder.rb:30)
<OBJECT ActiveRecord::LazyAttributeHash 0x7FB474CA1B30> (allocated at lib/active_record/attribute_set/builder.rb:16)
<OBJECT ActiveRecord::AttributeSet 0x7FB474CA1A68> (allocated at lib/active_record/attribute_set/builder.rb:17)
<OBJECT Repo 0x7FB474CA1A40> (allocated at activerecord-4.2.3/lib/active_record/core.rb:114)
<ARRAY 996 items 0x7FB474D790A8> (allocated at activerecord-4.2.3/lib/active_record/querying.rb:50)
<OBJECT Repo::ActiveRecord_Relation 0x7FB476A8BE98> (allocated at lib/active_record/relation/spawn_methods.rb:10)
<OBJECT PagesController 0x7FB476AB25C0> (allocated at actionpack-4.2.3/lib/action_controller/metal.rb:237)
<HASH 0x7FB4772EAE68> (allocated at rack-1.6.4/lib/rack/mock.rb:92)
<OBJECT ActionDispatch::Request 0x7FB476AB2480> (allocated at actionpack-4.2.3/lib/action_controller/metal.rb:237)
<OBJECT ActionDispatch::Response 0x7FB476AB2458> (allocated at lib/action_controller/metal/rack_delegation.rb:28)
<ROOT machine_context 0x2> (allocated at )

## All references to 0x7fb47763feb0
 * <HASH 0x7FB474CA1A90> (allocated at lib/active_record/attribute_set/builder.rb:30)

Enter address to inspect: 0x7FB476AB2480

## Reference chain
<OBJECT ActionDispatch::Request 0x7FB476AB2480> (allocated at actionpack-4.2.3/lib/action_controller/metal.rb:237)
<OBJECT ActionDispatch::Response 0x7FB476AB2458> (allocated at lib/action_controller/metal/rack_delegation.rb:28)
<ROOT machine_context 0x2> (allocated at )

## All references to 0x7FB476AB2480
 * <OBJECT ActionDispatch::Response 0x7FB476AB2458> (allocated at lib/action_controller/metal/rack_delegation.rb:28)
 * <OBJECT PagesController 0x7FB476AB25C0> (allocated at actionpack-4.2.3/lib/action_controller/metal.rb:237)

Enter address to inspect: 0x7FB476AB25C0

## Reference chain
<OBJECT PagesController 0x7FB476AB25C0> (allocated at actionpack-4.2.3/lib/action_controller/metal.rb:237)
<HASH 0x7FB4772EAE68> (allocated at rack-1.6.4/lib/rack/mock.rb:92)
<OBJECT ActionDispatch::Request 0x7FB476AB2480> (allocated at actionpack-4.2.3/lib/action_controller/metal.rb:237)
<OBJECT ActionDispatch::Response 0x7FB476AB2458> (allocated at lib/action_controller/metal/rack_delegation.rb:28)
<ROOT machine_context 0x2> (allocated at )

## All references to 0x7FB476AB25C0
 * <HASH 0x7FB4772EAE68> (allocated at rack-1.6.4/lib/rack/mock.rb:92)

Enter address to inspect: ^C
```

In the examples above we can see that the object in question (an AR attribute) was not yet collected, because the request is still running, which is still referenced by the response and a `PagesController` instance.

## Background & considerations

I wrote this as a simple ruby script to be able to diagnose a memory bloat where I had no clue why objects were not garbage collected. Since it worked out and was helpful, I thought I could try to propose this as an upstream addition to heapy. Please let me know if you think this could be useful.

Things that will probably need further extension/talking about:
* Loading a larger memory dump can take a significant amount of time (my own script contained a progress indicator: `print "#{f.pos / (1024 * 1024)} MiB\r" if line_number % 1000 == 0`)
* Formatting (and level of detail) of stack lines is probably something that's worth having a second look at
* Obtaining object addresses may be handled through heapy as well (so far I manually obtained them, e.g. like `grep generation\":100 my.dump`)