### PR TITLE
Allow to drill down into multiple generations

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,12 +123,18 @@ $ heapy read tmp/2015-10-01T10:18:59-05:00-heap.dump 17 --lines=6
 
 > Note: Default lines value is 50
 
-### Reviewing all generations
+### Reviewing multiple generations
 
 If you want to read all generations you can use the "all" directive
 
 ```
 $ heapy read tmp/2015-10-01T10:18:59-05:00-heap.dump all
+```
+
+Alternatively you can provide a range of generations that should be considered
+
+```
+$ heapy read tmp/2015-10-01T10:18:59-05:00-heap.dump 5-10
 ```
 
 You can also use T-Lo's online JS based [Heap Analyzer](http://tenderlove.github.io/heap-analyzer/) for visualizations. Another tool is [HARB](https://github.com/csfrancis/harb)

--- a/lib/heapy/analyzer.rb
+++ b/lib/heapy/analyzer.rb
@@ -27,13 +27,19 @@ module Heapy
       end
     end
 
-    def drill_down(generation_to_inspect, max_items_to_display)
+    def drill_down(generations_to_inspect, max_items_to_display)
       puts ""
-      puts "Analyzing Heap (Generation: #{generation_to_inspect})"
+      puts "Analyzing Heap (Generation: #{generations_to_inspect})"
       puts "-------------------------------"
       puts ""
 
-      generation_to_inspect = Integer(generation_to_inspect) unless generation_to_inspect == "all"
+      min_gen, max_gen = if generations_to_inspect == "all"
+                           [nil, nil]
+                         else
+                           generations_to_inspect.split("-").map { |gen| Integer(gen) }
+                         end
+
+      max_gen = min_gen if min_gen && !max_gen # single generation selected
 
       memsize_hash    = counters_hash
       count_hash      = counters_hash
@@ -49,7 +55,7 @@ module Heapy
         end
 
         generation = parsed["generation"] || 0
-        if generation_to_inspect == "all".freeze || generation == generation_to_inspect
+        if min_gen.nil? || (generation >= min_gen && generation <= max_gen)
           next unless parsed["file"]
 
           key = "#{ parsed["file"] }:#{ parsed["line"] }"
@@ -70,7 +76,7 @@ module Heapy
         end
       end
 
-      raise "not a valid Generation: #{generation_to_inspect.inspect}" if memsize_hash.empty?
+      raise "Nothing found in generation: #{generations_to_inspect.inspect}" if memsize_hash.empty?
 
       total_memsize = memsize_hash.inject(0){|count, (k, v)| count += v}
 

--- a/spec/heap_inspect_spec.rb
+++ b/spec/heap_inspect_spec.rb
@@ -36,6 +36,15 @@ describe Heapy do
     expect(out).to match("19046  String")
   end
 
+  it "drills down some" do
+    out = run("bin/heapy read #{ fixtures('dumps/00-heap.dump') } 35-36")
+    # memory count
+    expect(out).to match("377065  /Users/richardschneeman/Documents/projects/codetriage/app/views/layouts/application.html.slim:1")
+
+    # class counts
+    expect(out).to match("8220  String")
+  end
+
   it "drills down" do
     out = run("bin/heapy read #{ fixtures('dumps/00-heap.dump') } 36")
 


### PR DESCRIPTION
This allows to view aggregated results of multiple (possibly small each) generations, while still being more specific than aggregating all generations, which would include retained objects from the early boot of the inspected app.